### PR TITLE
Add ts type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,32 @@
+export type Rule = {
+  type: string;
+  start?: number;
+  and?: number;
+  bytes?: string;
+  rules?: Rule[];
+};
+
+export type Signature = {
+  type: string;
+  ext?: string;
+  mime?: string;
+  rules: Rule[]
+  desc?: string;
+}
+
+export type FileType = {
+  ext: string;
+  mime: string;
+};
+
+export type Callback = (err?: Error, type?: FileType) => any
+
+declare class DetectFileType {
+  static fromFile(filePath: string, bufferLength: number | Callback, callback?: Callback);
+  static fromFd(fd: number, bufferLength: number | Callback, callback?: Callback);
+  static fromBuffer(fd: Buffer, callback: Callback);
+  static addSignature(Signature);
+  static addCustomFunction(buffer: Buffer);
+}
+
+export = DetectFileType

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lib/index.js",
     "signatures.json"
   ],
+  "types": "index.d.ts",
   "author": {
     "name": "Dmitry Pavlovsky",
     "email": "dima@paloskin.me",


### PR DESCRIPTION
Related with https://github.com/dimapaloskin/detect-file-type/issues/20

@danielgindi Hello :) I noticed that some signatures do not have `ext` or `mime` props (for example [jpeg-2000](https://github.com/dimapaloskin/detect-file-type/blob/master/signatures.json#L841) or [heic](https://github.com/dimapaloskin/detect-file-type/blob/master/signatures.json#L916)). Is it expected?